### PR TITLE
fix: restore macro for attack_wave_2

### DIFF
--- a/src/NERVCommand.huff
+++ b/src/NERVCommand.huff
@@ -340,7 +340,7 @@
     __FUNC_SIG(eva_TEN) 0x00 mstore CONFIRM_EVA_CONTRACT()
 }
 
-#define fn ATTACK_WAVE2() = takes (1) returns (2) {
+#define macro ATTACK_WAVE2() = takes (1) returns (2) {
     __FUNC_SIG(eva_SEVEN) 0x00 mstore CALL_EVA_CONTRACT()
     __FUNC_SIG(eva_EIGHT) 0x00 mstore CALL_EVA_CONTRACT()
     __FUNC_SIG(eva_NINE)  0x00 mstore CALL_EVA_CONTRACT()


### PR DESCRIPTION
Fix for the test introduced an error for the NERDCommand contract.
Not sure yet whether this is related to compiler or not, but after getting out of ATTACK_WAVE2 if it's called as a function it jumps to some weird pc and reverts. Will continue reviewing but might help some folks trying to solve puzzle using foundry debugger