### PR TITLE
fix: change number of returned elements to stack in ATTACK_WAVE2

### DIFF
--- a/src/NERVCommand.huff
+++ b/src/NERVCommand.huff
@@ -340,7 +340,7 @@
     __FUNC_SIG(eva_TEN) 0x00 mstore CONFIRM_EVA_CONTRACT()
 }
 
-#define macro ATTACK_WAVE2() = takes (1) returns (2) {
+#define macro ATTACK_WAVE2() = takes (1) returns (1) {
     __FUNC_SIG(eva_SEVEN) 0x00 mstore CALL_EVA_CONTRACT()
     __FUNC_SIG(eva_EIGHT) 0x00 mstore CALL_EVA_CONTRACT()
     __FUNC_SIG(eva_NINE)  0x00 mstore CALL_EVA_CONTRACT()


### PR DESCRIPTION
There's only interaction with the top element on the stack:

```huff
#define macro ATTACK_WAVE2() = takes (1) returns (1) {
    // input stack: [some num, 0x0f00]
    __FUNC_SIG(eva_SEVEN) 0x00 mstore CALL_EVA_CONTRACT() // [num1, ...]
    __FUNC_SIG(eva_EIGHT) 0x00 mstore CALL_EVA_CONTRACT() // [num2, num1, ...]
    __FUNC_SIG(eva_NINE)  0x00 mstore CALL_EVA_CONTRACT() // [num3, num2, num1, ...]
    __FUNC_SIG(eva_TEN)   0x00 mstore CALL_EVA_CONTRACT() // [num4, num3, num2, num1, ...]

    // Angel neural resequencing
    add add add // [sum1, ...]
    0x07 0x20 calldataload exp // [num1, sum1, ...]
    0x08 0x40 calldataload exp // [num2, num1, sum1, ...]
    0x09 0x60 calldataload exp // [num3, num2, num1, sum1, ...]
    0x10 0x80 calldataload exp // [num4, num3, num2, num1, sum1, ...]
    add add add // [sum2, sum1, ...]

    dup1 swap2 eq ZERO_TIME_SOUL_SYNC(0x18)  // [sum2, some num, 0x0f00]
    swap1 add  // [sum2 + some num, 0xf00]
}
```
In case of successful execution the sum of 4 static calls to user deployed contract would be added to the top element on the stack.
Now it's safe to use it with both `macro` and `fn`